### PR TITLE
C-style comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test.*
 /__pycache__
 *.dc.json
 /.vscode
+blocktest.c

--- a/cli.py
+++ b/cli.py
@@ -45,22 +45,22 @@ cstyle_langs = {
 
 pythonstyle_langs = {
     ".py",  # Python
-    # ".rb",  # Ruby
-    # ".pl", ".pm",  # Perl
-    # ".r",   # R
-    # ".sh", ".bash",  # Shell
-    # ".ps1", ".psm1", ".psd1",  # PowerShell
-    # # "Makefile", "Makefile"  # Makefile
-    # # ".dockerfile", "Dockerfile"  # Dockerfile
-    # ".yaml", ".yml",  # YAML
-    # ".tcl",  # Tcl
-    # ".jl",  # Julia
-    # ".awk",  # Awk
-    # ".m",   # MATLAB
-    # ".coffee",  # CoffeeScript
-    # ".ex", ".exs",  # Elixir
-    # ".vim",  # Vim Script
-    # ".hs",  # Haskell
+    ".rb",  # Ruby
+    ".pl", ".pm",  # Perl
+    ".r",   # R
+    ".sh", ".bash",  # Shell
+    ".ps1", ".psm1", ".psd1",  # PowerShell
+    # "Makefile", "Makefile"  # Makefile
+    # ".dockerfile", "Dockerfile"  # Dockerfile
+    ".yaml", ".yml",  # YAML
+    ".tcl",  # Tcl
+    ".jl",  # Julia
+    ".awk",  # Awk
+    ".m",   # MATLAB
+    ".coffee",  # CoffeeScript
+    ".ex", ".exs",  # Elixir
+    ".vim",  # Vim Script
+    ".hs",  # Haskell
 }
 
 if __name__ == '__main__':
@@ -75,6 +75,7 @@ if __name__ == '__main__':
             dc.recomment()
             
     elif ext in cstyle_langs:
+        print('WARNING: C-style block comments result in unexpected behaviors and may not format correctly. A fix will be coming in the near future.')
         dc = Decommenter(fname, 'cstyle')
         if args.mode == 'decomment':
             print(f'Decommenting {fname}...')

--- a/cli.py
+++ b/cli.py
@@ -22,16 +22,66 @@ parser.add_argument(
 args = parser.parse_args()
 fname = args.file
 
+cstyle_langs = {
+    ".c",  # C 
+    ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hh",  # C++
+    ".cs",  # C#
+    ".java",  # java
+    ".js", ".mjs",  # javascript
+    ".m", ".mm", ".h",  # objective-c
+    ".go",  # go
+    ".php", ".phtml",  # php
+    ".rs",  # rust
+    ".swift",  # swift
+    ".scala", ".sc", ".sbt",  # scala
+    ".kt", ".kts",  # kotlin
+    ".d",  # d
+    ".ts", ".tsx",  # typescript
+    ".as",  # actionscript
+    ".hx",  # haxe
+    ".groovy", ".gvy", ".gy", ".gsh"  # groovy
+    
+}
+
+pythonstyle_langs = {
+    ".py",  # Python
+    # ".rb",  # Ruby
+    # ".pl", ".pm",  # Perl
+    # ".r",   # R
+    # ".sh", ".bash",  # Shell
+    # ".ps1", ".psm1", ".psd1",  # PowerShell
+    # # "Makefile", "Makefile"  # Makefile
+    # # ".dockerfile", "Dockerfile"  # Dockerfile
+    # ".yaml", ".yml",  # YAML
+    # ".tcl",  # Tcl
+    # ".jl",  # Julia
+    # ".awk",  # Awk
+    # ".m",   # MATLAB
+    # ".coffee",  # CoffeeScript
+    # ".ex", ".exs",  # Elixir
+    # ".vim",  # Vim Script
+    # ".hs",  # Haskell
+}
+
 if __name__ == '__main__':
-    ext = fname[fname.find('.')+1:]
-    match(ext):
-        case 'py':
-            dc = Decommenter(fname, 'python')
-            if args.mode == 'decomment':
-                print(f'Decommenting {fname}...')
-                dc.decomment()
-            elif args.mode == 'recomment':
-                print(f'Recommenting {fname}...')
-                dc.recomment()
-        case _:
-            print(f'Filetype "{ext}" not supported.')
+    ext = fname[fname.find('.'):]
+    if ext in pythonstyle_langs:
+        dc = Decommenter(fname, 'python')
+        if args.mode == 'decomment':
+            print(f'Decommenting {fname}...')
+            dc.decomment()
+        elif args.mode == 'recomment':
+            print(f'Recommenting {fname}...')
+            dc.recomment()
+            
+    elif ext in cstyle_langs:
+        dc = Decommenter(fname, 'cstyle')
+        if args.mode == 'decomment':
+            print(f'Decommenting {fname}...')
+            dc.decomment()
+        elif args.mode == 'recomment':
+            print(f'Recommenting {fname}...')
+            dc.recomment()
+            
+    else:
+        print(f'Filetype "{ext}" not supported.')

--- a/decomment.py
+++ b/decomment.py
@@ -167,10 +167,22 @@ class Decommenter():
             # if inline, append to code line
             # otherwise, insert new line with comment (matches indentation of following line) 
             if inline:
-                lines[linenum-1] = lines[linenum-1][:-1] + f'  {self.symbol} {comment}\n'
+                # print(f'Inline comment:\n\tLine {linenum}:', lines[linenum])
+                # print(f'\tCmnt:', comment)
+                # print('\tPrev:', lines[linenum-1])
+                try:
+                    lines[linenum-1] = lines[linenum-1][:-1] + f'  {self.symbol} {comment}\n'
+                except IndexError:
+                    lines.insert(linenum-1, '\n')
+                    lines[linenum-1] = lines[linenum-1][:-1] + f'  {self.symbol} {comment}\n'
             else:
-                ws = re.match(r"\s*", lines[linenum-1]).group(1)
-                lines.insert(linenum - 1, f'{ws}# {comment}\n')
+                try:
+                    ws = re.match(r"\s*", lines[linenum-1]).group()
+                except IndexError:
+                    lines.insert(linenum-1, '\n')
+                    ws = re.match(r"\s*", lines[linenum-1]).group()
+                    
+                lines.insert(linenum - 1, f'{ws}{self.symbol} {comment}\n')
         
         # write changes over original code
         self._write_code(lines)

--- a/decomment.py
+++ b/decomment.py
@@ -38,40 +38,131 @@ class Decommenter():
         with open(self.fname + '.dc.json', mode='w') as f:
             json.dump(comments, f)
     
-    # decomment code
+    # # decomment code
+    # def decomment(self):
+    #     # get original file
+    #     lines = self._get_code()
+        
+    #     dc_code, comments = [], []
+    #     for linenum, line in enumerate(lines, start=1):
+    #         # match comment that starts with a given symbol followed by exactly one space
+    #         # and the symbol is not preceded by a backslash
+    #         res = re.search(r'(?<!\\)' + self.symbol + r'\s(.*)', line)
+            
+    #         start_sym, end_sym = self.block_symbol
+    #         # TODO: handle block comments
+            
+    #         if res is not None:
+    #             # determine if it's an inline comment (if there's code before the comment)
+    #             inline = bool(line[:res.start()].strip())
+    #             comments.append({
+    #                 "inline":  inline,
+    #                 "linenum": linenum,
+    #                 "comment": res.group(1).strip()
+    #             })
+    #             if not inline:
+    #                 continue
+            
+    #         # remove comment from the code while retaining escaped cymbols
+    #         code_line = re.sub(r'(?<!\\)' + self.symbol + r'\s.*', '', line)
+    #         dc_code.append(code_line.rstrip() + '\n')  # Remove trailing whitespace only                 
+
+    #     self._write_code(dc_code)
+    #     self._write_comments(comments)
+            
+    #     print(f'{self.fname} decommented.')
+
     def decomment(self):
         # get original file
         lines = self._get_code()
         
         dc_code, comments = [], []
+        block_comment = False
+        block_comment_lines = []
+        
+        start_sym, end_sym = self.block_symbol
+        
         for linenum, line in enumerate(lines, start=1):
-            # match comment that starts with a given symbol followed by exactly one space
-            # and the symbol is not preceded by a backslash
-            res = re.search(r'(?<!\\)' + self.symbol + r'\s(.*)', line)
+            # Handle block comment start
+            res = re.search(r'(?<!\\)' + re.escape(start_sym) + r'(.*)', line)
             
-            # TODO: handle block comments
             
-            if res is not None:
-                # determine if it's an inline comment (if there's code before the comment)
-                inline = bool(line[:res.start()].strip())
-                comments.append({
-                    "inline":  inline,
-                    "linenum": linenum,
-                    "comment": res.group(1).strip()
-                })
-                if not inline:
+            # if not already in block comment and start symbol found
+            if not block_comment and res:
+                block_comment = True
+                s = res.group(1)
+                # this logic might leak certain situations involving a one-line block comment
+                # probably should convert to regex logic
+                # end_sym_idx = s.index(end_sym, res.pos) if end_sym in s else None
+                
+                end_sym_idx = re.search(r'(.*)(?<!\\)' + re.escape(end_sym), s).span()[0]
+                
+                # if end symbol found on same line (one-line block comment), extract 
+                # the block comment from the line and treat it as an inline comment
+                if end_sym_idx:
+                    block_comment = False
+                    comments.append({
+                        "inline":  True,
+                        "linenum": linenum,
+                        "comment": s[:end_sym_idx]
+                    })
+                    code_line = line[:res.span()[0]] + line[end_sym_idx + len(end_sym_idx):] # TODO: make regex?
+                    dc_code.append(code_line.rstrip() + '\n')  # Remove trailing whitespace only
                     continue
+                                
+                
+            # if in block comment and end symbol found (not on same line as start symbol)
+            if block_comment and res:
+                block_comment = False
+                comments.append({
+                        "inline":  True,
+                        "linenum": linenum,
+                        "comment": res.group(1)
+                    })
+                
+                # get whitespace of current line to indent the code and push code
+                ws = re.match(r"\s*", line).group(1)
+                code_line = re.sub(r'(.*)' + re.escape(end_sym), '', line)
+                dc_code.append(ws + code_line.rstrip() + '\n')  # Remove trailing whitespace only
+                    
             
-            # remove comment from the code while retaining escaped cymbols
-            code_line = re.sub(r'(?<!\\)' + self.symbol + r'\s.*', '', line)
-            dc_code.append(code_line.rstrip() + '\n')  # Remove trailing whitespace only                 
-
+            # if in block comment and no end symbol found
+            elif block_comment:
+                block_comment_lines.append({
+                    "inline":  False,
+                    "linenum": linenum,
+                    "comment": line.strip()
+                })
+                
+            # if not in block comment and no start symbol found
+            else:
+                # match inline comment that starts with a given symbol followed by exactly one space
+                # and the symbol is not preceded by a backslash
+                res = re.search(r'(?<!\\)' + re.escape(self.symbol) + r'\s(.*)', line)
+                
+                if res is not None:
+                    # determine if it's an inline comment (if there's code before the comment)
+                    inline = bool(line[:res.start()].strip())
+                    comments.append({
+                        "inline":  inline,
+                        "linenum": linenum,
+                        "comment": res.group(1).strip()
+                    })
+                    if not inline:
+                        continue
+                
+                # remove comment from the code while retaining escaped symbols
+                code_line = re.sub(r'(?<!\\)' + re.escape(self.symbol) + r'\s.*', '', line)
+                dc_code.append(code_line.rstrip() + '\n')  # Remove trailing whitespace only
+        
+        
         self._write_code(dc_code)
         self._write_comments(comments)
             
         print(f'{self.fname} decommented.')
-
-
+        
+        
+        
     # recomment python code
     def recomment(self):
         # load comments file
@@ -90,7 +181,7 @@ class Decommenter():
             if inline:
                 lines[linenum-1] = lines[linenum-1][:-1] + f'  {self.symbol} {comment}\n'
             else:
-                ws = re.match(r"\s*", lines[linenum-1]).group()
+                ws = re.match(r"\s*", lines[linenum-1]).group(1)
                 lines.insert(linenum - 1, f'{ws}# {comment}\n')
         
         # write changes over original code

--- a/decomment.py
+++ b/decomment.py
@@ -37,40 +37,6 @@ class Decommenter():
     def _write_comments(self, comments):
         with open(self.fname + '.dc.json', mode='w') as f:
             json.dump(comments, f)
-    
-    # # decomment code
-    # def decomment(self):
-    #     # get original file
-    #     lines = self._get_code()
-        
-    #     dc_code, comments = [], []
-    #     for linenum, line in enumerate(lines, start=1):
-    #         # match comment that starts with a given symbol followed by exactly one space
-    #         # and the symbol is not preceded by a backslash
-    #         res = re.search(r'(?<!\\)' + self.symbol + r'\s(.*)', line)
-            
-    #         start_sym, end_sym = self.block_symbol
-    #         # TODO: handle block comments
-            
-    #         if res is not None:
-    #             # determine if it's an inline comment (if there's code before the comment)
-    #             inline = bool(line[:res.start()].strip())
-    #             comments.append({
-    #                 "inline":  inline,
-    #                 "linenum": linenum,
-    #                 "comment": res.group(1).strip()
-    #             })
-    #             if not inline:
-    #                 continue
-            
-    #         # remove comment from the code while retaining escaped cymbols
-    #         code_line = re.sub(r'(?<!\\)' + self.symbol + r'\s.*', '', line)
-    #         dc_code.append(code_line.rstrip() + '\n')  # Remove trailing whitespace only                 
-
-    #     self._write_code(dc_code)
-    #     self._write_comments(comments)
-            
-    #     print(f'{self.fname} decommented.')
 
     def decomment(self):
         # get original file
@@ -78,7 +44,6 @@ class Decommenter():
         
         dc_code, comments = [], []
         block_comment = False
-        block_comment_lines = []
         
         start_sym, end_sym = self.block_symbol
         
@@ -87,55 +52,78 @@ class Decommenter():
             res = re.search(r'(?<!\\)' + re.escape(start_sym) + r'(.*)', line)
             
             
-            # if not already in block comment and start symbol found
+            # NOT BLOCK comment and START symbol found
             if not block_comment and res:
+                print('Start symbol found;\n\tLine: ', line)
                 block_comment = True
                 s = res.group(1)
                 # this logic might leak certain situations involving a one-line block comment
                 # probably should convert to regex logic
                 # end_sym_idx = s.index(end_sym, res.pos) if end_sym in s else None
                 
-                end_sym_idx = re.search(r'(.*)(?<!\\)' + re.escape(end_sym), s).span()[0]
-                
+                end_sym_idx = re.search(r'(.*)(?<!\\)' + re.escape(end_sym), s).span()[0] if re.search(r'(.*)(?<!\\)' + re.escape(end_sym), s) else None
+                print('\tEnd idx:', end_sym_idx)
                 # if end symbol found on same line (one-line block comment), extract 
                 # the block comment from the line and treat it as an inline comment
                 if end_sym_idx:
+                    print('End symbol found on same line')
                     block_comment = False
                     comments.append({
                         "inline":  True,
                         "linenum": linenum,
-                        "comment": s[:end_sym_idx]
+                        "comment": start_sym + s[:end_sym_idx]
                     })
                     code_line = line[:res.span()[0]] + line[end_sym_idx + len(end_sym_idx):] # TODO: make regex?
                     dc_code.append(code_line.rstrip() + '\n')  # Remove trailing whitespace only
-                    continue
-                                
                 
-            # if in block comment and end symbol found (not on same line as start symbol)
+                # IN BLOCK comment and START symbol found
+                else:
+                    print('\tNo end symbol found on same line\n')
+                    comments.append({
+                            "inline":  True,
+                            "linenum": linenum,
+                            "comment": start_sym + res.group(1)
+                        })
+                
+                    # get whitespace of current line to indent the code and push code
+                    ws = re.match(r"\s*", line).group()
+                    code_line = re.sub(r'(?<!\\)' + re.escape(start_sym) + r'(.*)$', '', line)
+                    print('\tCode:', code_line)
+                    dc_code.append(ws + code_line.rstrip() + '\n')
+                    # Remove trailing whitespace only        
+                    
+                continue    
+            
+            # IN BLOCK comment and END symbol found (not on same line as start symbol)
+            res = re.search(r'(.*)(?<!\\)' + re.escape(end_sym), line)
             if block_comment and res:
+                s = res.group(1)
+                print('End symbol found:\n\tLine:', line)
+                print('\tComment:', s[:end_sym_idx] + ' ' + end_sym)
                 block_comment = False
                 comments.append({
-                        "inline":  True,
-                        "linenum": linenum,
-                        "comment": res.group(1)
-                    })
-                
-                # get whitespace of current line to indent the code and push code
-                ws = re.match(r"\s*", line).group(1)
-                code_line = re.sub(r'(.*)' + re.escape(end_sym), '', line)
-                dc_code.append(ws + code_line.rstrip() + '\n')  # Remove trailing whitespace only
+                    "inline":  True,
+                    "linenum": linenum,
+                    "comment": s[:end_sym_idx] + ' ' + end_sym
+                })
+                # assumes that there is no code on the same line as the end symbol
+                # code_line = line[:res.span()[0]] + line[end_sym_idx + len(end_sym_idx):]
+                # dc_code.append(code_line.rstrip() + '\n')  # Remove trailing whitespace only
                     
             
-            # if in block comment and no end symbol found
+            # IN BLOCK comment and NO END symbol found
             elif block_comment:
-                block_comment_lines.append({
+                print('In block comment:\n\tLine:', line)
+                comments.append({
                     "inline":  False,
                     "linenum": linenum,
                     "comment": line.strip()
                 })
                 
-            # if not in block comment and no start symbol found
+                
+            # NOT BLOCK comment and NO START symbol found
             else:
+                print('Normal line:\n\tLine:', line)
                 # match inline comment that starts with a given symbol followed by exactly one space
                 # and the symbol is not preceded by a backslash
                 res = re.search(r'(?<!\\)' + re.escape(self.symbol) + r'\s(.*)', line)


### PR DESCRIPTION
# C-style block decommenting

This was a nightmare with the current line-by-line processing that the decommenter uses. Using it on lines where there's code on the line with a start or end symbol will cause abnormal behavior. Later, the code can be restructured to do multi-line regex which will massively simplify the code, but for now this works. Recommenting block comments technically works, in that it runs without errors and all of the comments are in the document. However, there are spacing issues and the program treats lines of block comments as newline comments and adds //s for c-style which isn't desired. And it still has issues with code and comments on the same line. This will get pushed to dev, but (as stated before) it will need to be revamped in the near future. 

This feature will remain in `dev` until the revamp.